### PR TITLE
Add CrystalDisk Shizuku apps with arm64 support

### DIFF
--- a/bucket/CrystalDiskInfo-Shizuku.json
+++ b/bucket/CrystalDiskInfo-Shizuku.json
@@ -1,0 +1,54 @@
+{
+    "version": "8.17.7",
+    "description": "A HDD/SSD utility software which supports a part of USB, Intel RAID and NVMe.",
+    "homepage": "https://crystalmark.info/en/",
+    "license": "MIT",
+    "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskinfo/77771/CrystalDiskInfo8_17_7Shizuku.zip",
+    "hash": "4b2bf845dc6ef837a6f355b437625956ac27dc5beaec35f81f22336596368822",
+    "architecture": {
+        "64bit": {
+            "shortcuts": [
+                [
+                    "DiskInfo64S.exe",
+                    "CrystalDiskInfo Shizuku Edition"
+                ]
+            ]
+        },
+        "32bit": {
+            "shortcuts": [
+                [
+                    "DiskInfo32S.exe",
+                    "CrystalDiskInfo Shizuku Edition"
+                ]
+            ]
+        },
+        "arm64": {
+            "shortcuts": [
+                [
+                    "DiskInfoA64S.exe",
+                    "CrystalDiskInfo Shizuku Edition"
+                ]
+            ]
+        }
+    },
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\DiskInfo.ini\")) {",
+        "    New-Item \"$dir\\DiskInfo.ini\" -ItemType File | Out-Null",
+        "}"
+    ],
+    "persist": [
+        "DiskInfo.ini",
+        "Smart"
+    ],
+    "checkver": {
+        "url": "https://osdn.net/projects/crystaldiskinfo/",
+        "regex": "<a href=\"/projects/crystaldiskinfo/releases/(?<release>[\\d]*)\">CrystalDiskInfo ([\\d+\\.*]+)</a>"
+    },
+    "autoupdate": {
+        "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskinfo/$matchRelease/CrystalDiskInfo$underscoreVersionShizuku.zip",
+        "hash": {
+            "url": "https://osdn.net/projects/crystaldiskinfo/releases/rss",
+            "xpath": "//osdn:file[@url='https://osdn.net/projects/crystaldiskinfo/downloads/$matchRelease/CrystalDiskInfo$underscoreVersionShizuku.zip/']/@sha256"
+        }
+    }
+}

--- a/bucket/CrystalDiskMark-Shizuku.json
+++ b/bucket/CrystalDiskMark-Shizuku.json
@@ -1,6 +1,6 @@
 {
     "version": "8.0.4b",
-    "description": "CrystalDiskMark is a simple disk benchmark software.",
+    "description": "A simple disk benchmark software.",
     "homepage": "https://crystalmark.info/en/",
     "license": "MIT",
     "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskmark/77539/CrystalDiskMark8_0_4bShizuku.zip",

--- a/bucket/CrystalDiskMark-Shizuku.json
+++ b/bucket/CrystalDiskMark-Shizuku.json
@@ -1,0 +1,57 @@
+{
+    "version": "8.0.4b",
+    "description": "CrystalDiskMark is a simple disk benchmark software.",
+    "homepage": "https://crystalmark.info/en/",
+    "license": "MIT",
+    "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskmark/77539/CrystalDiskMark8_0_4bShizuku.zip",
+    "hash": "ee15f4782258e8d64a050859d22fe72077e671bccda4608cb2953a1b44a47bd6",
+    "architecture": {
+        "64bit": {
+            "shortcuts": [
+                [
+                    "DiskMark64S.exe",
+                    "CrystalDiskMark Shizuku Edition"
+                ]
+            ]
+        },
+        "32bit": {
+            "shortcuts": [
+                [
+                    "DiskMark32S.exe",
+                    "CrystalDiskMark Shizuku Edition"
+                ]
+            ]
+        },
+        "arm64": {
+            "shortcuts": [
+                [
+                    "DiskMarkA64S.exe",
+                    "CrystalDiskMark Shizuku Edition"
+                ]
+            ]
+        }
+    },
+    "pre_install": [
+        "'DiskMark32S.ini', 'DiskMark64S.ini', 'DiskMarkA64S.ini' | ForEach-Object {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) {",
+        "        New-Item \"$dir\\$_\" -ItemType File | Out-Null",
+        "    }",
+        "}"
+    ],
+    "persist": [
+        "DiskMark32S.ini",
+        "DiskMark64S.ini",
+        "DiskMarkA64S.ini"
+    ],
+    "checkver": {
+        "url": "https://osdn.net/projects/crystaldiskmark/",
+        "regex": "releases/(?<release>[\\d]+)\">CrystalDiskMark ([\\w.]+)<"
+    },
+    "autoupdate": {
+        "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskmark/$matchRelease/CrystalDiskMark$underscoreVersionShizuku.zip",
+        "hash": {
+            "url": "https://osdn.net/projects/crystaldiskmark/releases/rss",
+            "xpath": "//osdn:file[@url='https://osdn.net/projects/crystaldiskmark/downloads/$matchRelease/CrystalDiskMark$underscoreVersionShizuku.zip/']/@sha256"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Add CrystalDisk Shizuku apps with `arm64` architecture support since [scoop 0.3.0](https://github.com/ScoopInstaller/Scoop/pull/5162)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
